### PR TITLE
Update text-decoration-skip-ink and bump version

### DIFF
--- a/assets/generic/_reset.css
+++ b/assets/generic/_reset.css
@@ -11,7 +11,7 @@ html {
 
 body {
 	margin: 0;
-	text-decoration-skip: ink;
+	text-decoration-skip-ink: auto;
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 	text-size-adjust: none;

--- a/main.css
+++ b/main.css
@@ -1,4 +1,4 @@
-/*! normalize.css v8.0.0 | MIT License | github.com/csstools/normalize.css */
+/*! normalize.css v9.0.1 | MIT License | github.com/csstools/normalize.css */
 
 /* Document
  * ========================================================================== */
@@ -116,14 +116,12 @@ svg:not(:root) {
  * ========================================================================== */
 
 /**
- * Remove the margin in Firefox and Safari.
+ * Remove the margin in Safari.
  */
 
 button,
 input,
-optgroup,
-select,
-textarea {
+select {
   margin: 0;
 }
 
@@ -149,26 +147,6 @@ button,
 }
 
 /**
- * Remove the inner border and padding in Firefox.
- */
-
-::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
-}
-
-/**
- * Restore the focus styles unset by the previous rule in Firefox.
- */
-
-button:-moz-focusring,
-[type="button"]:-moz-focusring,
-[type="reset"]:-moz-focusring,
-[type="submit"]:-moz-focusring {
-  outline: 1px dotted ButtonText;
-}
-
-/**
  * Correct the padding in Firefox.
  */
 
@@ -187,8 +165,6 @@ input {
 /**
  * 1. Correct the text wrapping in Edge and IE.
  * 2. Correct the color inheritance from `fieldset` elements in IE.
- * 3. Remove the padding so developers are not caught out when they zero out
- *    `fieldset` elements in all browsers.
  */
 
 legend {
@@ -196,7 +172,6 @@ legend {
   color: inherit; /* 2 */
   display: table; /* 1 */
   max-width: 100%; /* 1 */
-  padding: 0; /* 3 */
   white-space: normal; /* 1 */
 }
 
@@ -219,20 +194,13 @@ select {
 }
 
 /**
- * Remove the default vertical scrollbar in IE.
+ * 1. Remove the margin in Firefox and Safari.
+ * 2. Remove the default vertical scrollbar in IE.
  */
 
 textarea {
-  overflow: auto;
-}
-
-/**
- * Correct the cursor style of increment and decrement buttons in Chrome.
- */
-
-::-webkit-inner-spin-button,
-::-webkit-outer-spin-button {
-  height: auto;
+  margin: 0; /* 1 */
+  overflow: auto; /* 2 */
 }
 
 /**
@@ -243,6 +211,24 @@ textarea {
 [type="search"] {
   -webkit-appearance: textfield; /* 1 */
   outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Safari.
+ */
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * Correct the text style of placeholders in Chrome, Edge, and Safari.
+ */
+
+::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
 }
 
 /**
@@ -261,6 +247,23 @@ textarea {
 ::-webkit-file-upload-button {
   -webkit-appearance: button; /* 1 */
   font: inherit; /* 2 */
+}
+
+/**
+ * Remove the inner border and padding of focus outlines in Firefox.
+ */
+
+::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus outline styles unset by the previous rule in Firefox.
+ */
+
+:-moz-focusring {
+  outline: 1px dotted ButtonText;
 }
 
 /* Interactive
@@ -333,7 +336,6 @@ template {
 	--font-size-h2: 1.75rem;
 	--font-size-h3: 1.5rem;
 	--font-size-h4: 1.25rem;
-	--font-size-h5: 1rem;
 	--font-size-h5: var(--font-size-base);
 	--font-size-h6: 0.75rem;
 }
@@ -380,7 +382,7 @@ html {
 body {
 	margin: 0;
 	-webkit-text-decoration-skip: ink;
-	        text-decoration-skip: ink;
+	        text-decoration-skip-ink: auto;
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 	-webkit-text-size-adjust: none;
@@ -546,8 +548,8 @@ textarea,
 /* Elements */
 /* Document */
 html {
-	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+	-webkit-tap-highlight-color: color-mod(#000 alpha(0%));
+	-webkit-tap-highlight-color: color-mod(var(--color-black) alpha(0%));
 }
 body {
 	font-family: sans-serif;
@@ -559,6 +561,7 @@ body {
 	color: #000;
 	color: var(--color-black);
 	min-width: 20rem;
+	margin: 0;
 	background-color: #fff;
 	background-color: var(--color-white);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "itcss",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "CSS starter boilerplate based on the ITCSS pattern",
 	"scripts": {
 		"build": "postcss index.css -o main.css -c postcss.config.js"


### PR DESCRIPTION
This PR updates `text-decoration-skip-ink` to the latest spec.
The master stylesheet is updated based on the latest `normalise.css` version.